### PR TITLE
Dockerisation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+ARG BUILD_TOOLS_VERSION="36.0.0"
+ARG APKTOOL_VERSION="2.11.1"
+
+FROM python:3.13-slim
+
+ARG BUILD_TOOLS_VERSION
+ARG APKTOOL_VERSION
+
+WORKDIR /xapktoapk
+COPY xapktoapk.py docker/entrypoint.sh ./
+
+# Dependencies: wget, java, keytool, zipalign, apksigner, apktool
+RUN apt update && apt -y install wget sdkmanager default-jdk-headless
+RUN sdkmanager --install "build-tools;${BUILD_TOOLS_VERSION}"
+ENV PATH="$PATH:/opt/android-sdk/build-tools/${BUILD_TOOLS_VERSION}"
+RUN \
+	wget -q https://raw.githubusercontent.com/iBotPeaches/Apktool/master/scripts/linux/apktool -O /usr/local/bin/apktool && \
+	wget -q https://bitbucket.org/iBotPeaches/apktool/downloads/apktool_${APKTOOL_VERSION}.jar -O /usr/local/bin/apktool.jar && \
+	chmod +x /usr/local/bin/apktool /usr/local/bin/apktool.jar
+
+ENTRYPOINT [ "./entrypoint.sh" ]

--- a/README.md
+++ b/README.md
@@ -58,3 +58,22 @@ The `sign.keystore.file` value in the example above is for Linux. Set the absolu
 
 By default, the resigning of the result apk files is disabled.
 If you do not want to sign it automatically, you don't have to do it. You can just sign the apk file manually after the conversion is completed.
+
+### Docker
+
+Alternatively you can build and use the docker image to have a readily available environment. Ensure you have a folder containing your XAPK to mount to the container. 
+```bash
+docker build -t xapktoapk .
+docker run --rm -it -v ./data:/mnt/data xapktoapk /mnt/data/app.xapk
+```
+You may optionally mount your own properties and truststore.
+```bash
+docker build -t xapktoapk .
+docker run --rm -it \
+	-v ./data:/mnt/data xapktoapk /mnt/data/app.xapk \
+	-v ./home/username/.android/debug.keystore:/mnt/debug.keystore:ro \
+	-v ./xapktoapk.sign.properties:/xapktoapk/xapktoapk.sign.properties:ro \ # `sign.keystore.file` should point to `/mnt/debug.keystore`
+	xapktoapk \
+	/mnt/data/app.xapk
+```
+The converted `.apk` file will be available in the `data` folder. 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+if [ ! -f "xapktoapk.sign.properties" -a ! -f "xapktoapk.keystore" ]; then
+    	echo "xapktoapk.sign.properties and xapktoapk.keystore not found, create a configuration with a randomly generated key."
+	PASSWORD="$(LC_ALL=C tr -dc '[:alnum:]' < /dev/urandom | head -c20)"
+	echo "Generated password: $PASSWORD"
+    	keytool \
+		-genkey \
+		-v \
+		-keystore xapktoapk.keystore \
+		-alias xapktoapk \
+		-keyalg RSA \
+		-keysize 2048 \
+		-validity 10000 \
+		-storepass "$PASSWORD" \
+		-keypass "$PASSWORD" \
+		-dname "CN=xapktoapk, OU=xapktoapk, O=xapktoapk, L=xapktoapk, S=xapktoapk, C=US"
+	cat <<-EOF > xapktoapk.sign.properties
+		sign.enabled=true
+		sign.keystore.file=/xapktoapk/xapktoapk.keystore 
+		sign.keystore.password=$PASSWORD
+		sign.key.alias=xapktoapk
+		sign.key.password=$PASSWORD
+	EOF
+fi
+
+python xapktoapk.py "$@"


### PR DESCRIPTION
Dockerise the application which should make it easier to run straight out of the box. When running it locally I had to figure out it wouldn't work due to improper / incorrect versions of the various dependencies resulting in cryptic error messages as previously raised in https://github.com/LuigiVampa92/xapk-to-apk/issues/2, https://github.com/LuigiVampa92/xapk-to-apk/issues/5, and https://github.com/LuigiVampa92/xapk-to-apk/issues/8.

As follow a full run output from build for your convenience:
```
$ docker build -t xapktoapk .
DEPRECATED: The legacy builder is deprecated and will be removed in a future release.
            Install the buildx component to build images with BuildKit:
            https://docs.docker.com/go/buildx/

Sending build context to Docker daemon  52.78MB
Step 1/12 : ARG BUILD_TOOLS_VERSION="36.0.0"
Step 2/12 : ARG APKTOOL_VERSION="2.11.1"
Step 3/12 : FROM python:3.13-slim
 ---> 26fa9b6e2848
Step 4/12 : ARG BUILD_TOOLS_VERSION
 ---> Using cache
 ---> 89529d8af62c
Step 5/12 : ARG APKTOOL_VERSION
 ---> Using cache
 ---> 8620038e7385
Step 6/12 : WORKDIR /xapktoapk
 ---> Using cache
 ---> daef8071060a
Step 7/12 : COPY xapktoapk.py docker/entrypoint.sh ./
 ---> Using cache
 ---> c42860bc3602
Step 8/12 : RUN apt update && apt -y install wget sdkmanager default-jdk-headless
 ---> Using cache
 ---> 94aab552f2f9
Step 9/12 : RUN sdkmanager --install "build-tools;${BUILD_TOOLS_VERSION}"
 ---> Using cache
 ---> 24b58f648ce4
Step 10/12 : ENV PATH="$PATH:/opt/android-sdk/build-tools/${BUILD_TOOLS_VERSION}"
 ---> Using cache
 ---> 874ab814fd0d
Step 11/12 : RUN        wget -q https://raw.githubusercontent.com/iBotPeaches/Apktool/master/scripts/linux/apktool -O /usr/local/bin/apktool &&         wget -q https://bitbucket.org/iBotPeaches/apktool/downloads/apktool_${APKTOOL_VERSION}.jar -O /usr/local/bin/apktool.jar &&        chmod +x /usr/local/bin/apktool /usr/local/bin/apktool.jar
 ---> Using cache
 ---> 64094f09d1b5
Step 12/12 : ENTRYPOINT [ "./entrypoint.sh" ]
 ---> Using cache
 ---> 03e48676c693
Successfully built 03e48676c693
Successfully tagged xapktoapk:latest
$ ls data/
app.xapk
$ docker run --rm -it -v ./data:/mnt/data xapktoapk /mnt/data/app.xapk
xapktoapk.sign.properties and xapktoapk.keystore not found, create a configuration with a randomly generated key.
Generated password: VjKGOPE5Q7aVzQWfBZpY
Generating 2,048 bit RSA key pair and self-signed certificate (SHA256withRSA) with a validity of 10,000 days
        for: CN=xapktoapk, OU=xapktoapk, O=xapktoapk, L=xapktoapk, ST=xapktoapk, C=US
[Storing xapktoapk.keystore]
[*] start
[*] unpacking xapk
[*] xapk file unpacked. 20 parts discovered
[*] unpacking 1 of 20
[*] unpacking 2 of 20
[*] unpacking 3 of 20
[*] unpacking 4 of 20
[*] unpacking 5 of 20
[*] unpacking 6 of 20
[*] unpacking 7 of 20
[*] unpacking 8 of 20
[*] unpacking 9 of 20
[*] unpacking 10 of 20
[*] unpacking 11 of 20
[*] unpacking 12 of 20
[*] unpacking 13 of 20
[*] unpacking 14 of 20
[*] unpacking 15 of 20
[*] unpacking 16 of 20
[*] unpacking 17 of 20
[*] unpacking 18 of 20
[*] unpacking 19 of 20
[*] unpacking 20 of 20
[*] repack apk
[*] zipalign apk
[*] resign apk
[*] complete
$ ls data/
app.apk  app.xapk
```